### PR TITLE
Support dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ const config = {
   width: 900, // chart width
   height: 300, // chart height
   preview: false, // if true points wont be draggable
+  darkMode: false, // Whether the dark color scheme is to be used
+  backgroundColor: 'transparent', // Color to be used as bg, Use true for default color
   footerText: {
     // control footer text
     show: true,

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -115,6 +115,51 @@ describe('hillchart@init', () => {
       `translate(${config.margin.left}, ${config.margin.top})`
     );
   });
+
+  it('defaults to a transparent background', () => {
+    setupHillChart();
+    expect(svg.getAttribute('style')).toEqual(
+      'stroke-width: 0; background-color: transparent;'
+    );
+  });
+
+  it('defaults to a light theme', () => {
+    const hill = setupHillChart();
+    expect(hill.darkMode).toEqual(false);
+    expect(svg.getAttribute('class')).toEqual('hill-chart-light');
+  });
+
+  it('supports enabling dark mode', () => {
+    config.darkMode = true;
+    const hill = setupHillChart();
+    expect(hill.darkMode).toEqual(true);
+    expect(svg.getAttribute('class')).toEqual('hill-chart-dark');
+  });
+
+  it('defaults to the appropriate light mode backgroundColor', () => {
+    config.backgroundColor = true;
+    setupHillChart();
+    expect(svg.getAttribute('style')).toEqual(
+      'stroke-width: 0; background-color: #ffffff;'
+    );
+  });
+
+  it('defaults to the appropriate dark mode backgroundColor', () => {
+    config.backgroundColor = true;
+    config.darkMode = true;
+    setupHillChart();
+    expect(svg.getAttribute('style')).toEqual(
+      'stroke-width: 0; background-color: #2f3437;'
+    );
+  });
+
+  it('supports defining a specific backgroundColor', () => {
+    config.backgroundColor = '#000';
+    setupHillChart();
+    expect(svg.getAttribute('style')).toEqual(
+      'stroke-width: 0; background-color: #000;'
+    );
+  });
 });
 
 describe('hillchart@render', () => {

--- a/demo/index.html
+++ b/demo/index.html
@@ -287,7 +287,6 @@
           description: 'Late af task',
           size: 10,
           x: 12.069770990416055,
-          y: 12.069770990416057,
           link: '/fired.html',
         },
 
@@ -301,7 +300,6 @@
           color: 'green',
           description: 'Hell yeah!',
           x: 93.48837209302326,
-          y: 6.511627906976724,
           size: 10,
         },
       ];

--- a/demo/index.html
+++ b/demo/index.html
@@ -332,10 +332,16 @@
         },
       ];
 
+      const qs = window.location.search || '';
+      const darkMode = qs.indexOf('darkMode=true') > -1;
+      const backgroundColor = darkMode ? true : false;
+
       const hill = new HillChart(data, {
         target: '.hill-chart',
         width: 700,
         height: 270,
+        darkMode,
+        backgroundColor,
         preview: false,
         footerText: {
           show: true,

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ const defaults = {
   width: 900,
   height: 300,
   preview: false,
+  darkMode: false,
+  backgroundColor: 'transparent',
   footerText: {
     show: true,
     fontSize: 0.75,
@@ -51,9 +53,18 @@ export default class HillChart extends EventEmitter {
     this.chartHeight = height - margin.top - margin.bottom;
 
     // Render the svg and center chart according to margins
+    const colorScheme = this.darkMode ? 'hill-chart-dark' : 'hill-chart-light';
+    const defaultBg = this.darkMode ? '#2f3437' : '#ffffff';
+    const useDefaultBg = this.backgroundColor === true;
+    const useTransparentBg = this.backgroundColor === false;
+    const suppliedBgColor = useDefaultBg ? defaultBg : this.backgroundColor;
+    const backgroundColor = useTransparentBg ? 'transparent' : suppliedBgColor;
+
     this.svg = select(target)
+      .attr('class', colorScheme)
       .attr('width', width)
       .attr('height', height)
+      .attr('style', `stroke-width: 0; background-color: ${backgroundColor};`)
       .append('g')
       .attr('transform', `translate(${margin.left}, ${margin.top})`);
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,18 +53,18 @@ export default class HillChart extends EventEmitter {
     this.chartHeight = height - margin.top - margin.bottom;
 
     // Render the svg and center chart according to margins
-    const colorScheme = this.darkMode ? 'hill-chart-dark' : 'hill-chart-light';
+    this.colorScheme = this.darkMode ? 'hill-chart-dark' : 'hill-chart-light';
     const defaultBg = this.darkMode ? '#2f3437' : '#ffffff';
     const useDefaultBg = this.backgroundColor === true;
     const useTransparentBg = this.backgroundColor === false;
     const suppliedBgColor = useDefaultBg ? defaultBg : this.backgroundColor;
-    const backgroundColor = useTransparentBg ? 'transparent' : suppliedBgColor;
+    this.backgroundColor = useTransparentBg ? 'transparent' : suppliedBgColor;
 
     this.svg = select(target)
-      .attr('class', colorScheme)
+      .attr('class', this.colorScheme)
       .attr('width', width)
       .attr('height', height)
-      .attr('style', `stroke-width: 0; background-color: ${backgroundColor};`)
+      .attr('style', `stroke-width: 0; background-color: ${this.backgroundColor};`)
       .append('g')
       .attr('transform', `translate(${margin.left}, ${margin.top})`);
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,37 +1,72 @@
 .chart-hill-main-curve {
   fill: none;
   opacity: 0.67;
-  stroke: #6d6d6d;
   stroke-width: 1.5px;
 }
 
+.hill-chart-light .chart-hill-main-curve {
+  stroke: #6d6d6d;
+}
+
+.hill-chart-dark .chart-hill-main-curve {
+  stroke: #7d7d7d;
+}
+
 .hill-chart-circle {
-  stroke: #fff;
   stroke-width: 2;
+}
+
+.hill-chart-light .hill-chart-circle {
+  stroke: #fff;
+}
+
+.hill-chart-dark .hill-chart-circle {
+  stroke: #2b2b2b;
 }
 
 .hill-chart-middle-line {
   fill: none;
-  stroke: #cbd5e0;
   stroke-width: 2.09px;
   shape-rendering: crispEdges;
   stroke-dasharray: 5, 5;
 }
 
+.hill-chart-light .hill-chart-middle-line {
+  stroke: #cbd5e0;
+}
+
+.hill-chart-dark .hill-chart-middle-line {
+  stroke: #7c7c7c;
+}
+
 .hill-chart-bottom-line path {
-  stroke: #bbb6b6;
   stroke-width: 1px;
+}
+
+.hill-chart-light .hill-chart-bottom-line path {
+  stroke: #bbb6b6;
+}
+
+.hill-chart-dark .hill-chart-bottom-line path {
+  stroke: #7c7c7c;
 }
 
 .hill-chart-text {
   font-family: inherit;
   text-transform: uppercase;
-  fill: #646464;
   letter-spacing: 0.05rem;
   text-anchor: middle;
   shape-rendering: crispEdges;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.hill-chart-light .hill-chart-text {
+  fill: #646464;
+}
+
+.hill-chart-dark .hill-chart-text {
+  fill: #a5a5a5;
 }
 
 .hill-chart-group {
@@ -45,4 +80,12 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-size: 1rem;
+}
+
+.hill-chart-light .hill-chart-group > text {
+  fill: #000;
+}
+
+.hill-chart-dark .hill-chart-group > text {
+  fill: #b5b5b5;
 }


### PR DESCRIPTION
I apologize for the typo in the demo that you had to fix, I had renamed the method and forgot to go back to the demo

I know this change doesn't address your core todo list, but I really want to use the charts in a dark website and the colors need to be adjustable for it to be readable... this makes a sane default dark mode as well as an option to set a bg color.

The default dark color scheme:

![](https://cln.sh/gzO5cs+)

You can use `index.html?darkMode=true` (when the includes use the local build) to preview.